### PR TITLE
Add InterceptorException

### DIFF
--- a/src/Dora.DynamicProxy/Dora.DynamicProxy/InterceptorException.cs
+++ b/src/Dora.DynamicProxy/Dora.DynamicProxy/InterceptorException.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Dora.DynamicProxy
+{
+    /// <summary>
+    /// Represents an InterceptorException.
+    /// </summary>
+    public class InterceptorException : Exception
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool RequireThrow { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="innerException"></param>
+        /// <param name="requireThrow"></param>
+        public InterceptorException(string message, Exception innerException, bool requireThrow = true)
+              : base(message, innerException)
+        {
+            RequireThrow = requireThrow;
+        }
+    }
+}


### PR DESCRIPTION
增加一个异常类型，通过其RequireThrow属性判断是否需要抛出异常。

用途：可通过此异常结合自定义IInterceptorProviderResolver的实现完成类似参数拦截的功能
```
   registry.Add(new MethodParameterInterceptorAttribute(), method =>
            {
                var parameters = method.GetParameters();
                var result = parameters.Any(x => x.GetCustomAttributes(false).Any(y => y is ParameterInterceptorAttribute));
                return result;
            });
```


```
   try
                    {
                        interceptor.PreHandleParameter(item.Parameter, item.ParameterValue, context);
                    }
                    catch (Exception ex)
                    {
                        throw new InterceptorException("'{0}'方法的'{1}'参数拦截器'{2}'处理异常".Fill($"{context.Method.DeclaringType.FullName}.{context.Method.Name}", item.Parameter.Name, interceptor.GetType().Name), ex, false);
                    }
```