### PR TITLE
fix generatetype assembly ref issue

### DIFF
--- a/src/Interception/Interception/CodeGeneration/CodeGenerationContext.cs
+++ b/src/Interception/Interception/CodeGeneration/CodeGenerationContext.cs
@@ -25,6 +25,24 @@ namespace Dora.Interception.CodeGeneration
             typeof(CodeGenerationContext).Assembly
         };
 
+        /// <summary>
+        /// Add reference, support generic type
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public ISet<Assembly> AddReference(Type type)
+        {
+            if (type.IsGenericType)
+            {
+                var types = type.GetGenericArguments();
+                foreach (var t in types)
+                   return AddReference(t);
+            }
+            else
+                this.References.Add(type.Assembly);
+            return References;
+        }
+
         /// <summary>Gets the indent level.</summary>
         /// <value>The indent level.</value>
         public int IndentLevel { get; private set; }

--- a/src/Interception/Interception/CodeGeneration/InterfaceProxyGenerator.cs
+++ b/src/Interception/Interception/CodeGeneration/InterfaceProxyGenerator.cs
@@ -50,10 +50,10 @@ namespace Dora.Interception.CodeGeneration
 
             foreach (var method in methods)
             {
-                codeGenerationContext.References.Add(method.ReturnType.Assembly);
+                codeGenerationContext.AddReference(method.ReturnType);
                 foreach (var parameter in method.GetParameters())
                 {
-                    codeGenerationContext.References.Add(parameter.ParameterType.Assembly);
+                    codeGenerationContext.AddReference(parameter.ParameterType);
                 }
             }
 

--- a/src/Interception/Interception/CodeGeneration/VirtualMethodProxyGenerator.cs
+++ b/src/Interception/Interception/CodeGeneration/VirtualMethodProxyGenerator.cs
@@ -203,10 +203,10 @@ namespace Dora.Interception.CodeGeneration
 
             foreach (var method in interceptableMethods)
             {                
-                codeGenerationContext.References.Add(method.ReturnType.Assembly);
+                codeGenerationContext.AddReference(method.ReturnType);
                 foreach (var parameter in method.GetParameters())
                 {
-                    codeGenerationContext.References.Add(parameter.ParameterType.Assembly);
+                    codeGenerationContext.AddReference(parameter.ParameterType);
                 }
             }
 


### PR DESCRIPTION
When I regist interception to the method which have return or parameter of generatetype, for example:

public virtual async Task< Class2 > Invoke(); // Class2 is from another assembly.

 I got the error:

Dora.Interception.InterceptionException:“It fails to generate proxy class. 
 (69,60): error CS0246: 未能找到类型或命名空间名“ClassLibrary1”(是否缺少 using 指令或程序集引用?)
(69,82): error CS0012: 类型“Class2”在未引用的程序集中定义。必须添加对程序集“ClassLibrary1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null”的引用。
(16,50): error CS0246: 未能找到类型或命名空间名“ClassLibrary1”(是否缺少 using 指令或程序集引用?)
(59,141): error CS0246: 未能找到类型或命名空间名“ClassLibrary1”(是否缺少 using 指令或程序集引用?)
(60,189): error CS0246: 未能找到类型或命名空间名“ClassLibrary1”(是否缺少 using 指令或程序集引用?)
(82,31): error CS0012: 类型“Class2”在未引用的程序集中定义。必须添加对程序集“ClassLibrary1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null”的引用。
(83,36): error CS0029: 无法将类型“System.Threading.Tasks.Task<ClassLibrary1.Class2>”隐式转换为“System.Threading.Tasks.Task<ClassLibrary1.Class2>””

I found the reason:
The method CodeGenerationContext.References.Add(Assembly assembly) can not add the assemly for the parameter of generatetype.

Fix:
Add a method AddReference, if the type is generatetype, add the assembly recursively.
